### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "sshbind"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "age",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshbind"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 authors = ["Maximilian Philipp <maxkon2000@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `sshbind`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1] - 2025-01-26

### Added

- GitHub Actions workflow for publishing to crates.io
- GitHub Actions workflow for automated releases with release-plz
- CD/CI pipeline for continuous deployment
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).